### PR TITLE
add rateLimitHandler middleware with tests

### DIFF
--- a/src/config/rate-limit.ts
+++ b/src/config/rate-limit.ts
@@ -1,11 +1,13 @@
 import { rateLimit } from 'express-rate-limit';
 import express from 'express';
+import { rateLimitHandler } from '../middleware/rateLimitHandler.middleware';
 
 export const configureRateLimit = (app: express.Application) => {
     app.use(rateLimit({
         windowMs: 15 * 60 * 1000, // 15 minutes
         limit: 100, // Limit each IP to 100 requests per window
         standardHeaders: 'draft-7', // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
-        legacyHeaders: false // Disable the `X-RateLimit-*` headers.
+        legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+        handler: rateLimitHandler
     }));
 };

--- a/src/middleware/rateLimitHandler.middleware.ts
+++ b/src/middleware/rateLimitHandler.middleware.ts
@@ -1,0 +1,8 @@
+import { errorHandler } from '../controller/error.controller';
+import { Request, Response, NextFunction } from 'express';
+
+export const rateLimitHandler = (req: Request, res: Response, next: NextFunction) => {
+    const err = new Error('Too Many Requests');
+    res.statusCode = 429;
+    errorHandler(err, req, res, next);
+};

--- a/test/mock/data.ts
+++ b/test/mock/data.ts
@@ -1,3 +1,5 @@
+import { jest, expect } from '@jest/globals';
+
 import * as config from '../../src/config';
 import express from 'express';
 import { AddMemberKey } from '../../src/model/add-member.model';
@@ -71,7 +73,8 @@ export const MOCK_RATE_LIMIT_VALUE = {
     windowMs: 15 * 60 * 1000,
     limit: 100,
     standardHeaders: 'draft-7',
-    legacyHeaders: false
+    legacyHeaders: false,
+    handler: expect.any(Function)
 };
 
 export const MOCK_EXPRESS_APP = {

--- a/test/unit/middleware/rateLimitHandler.middleware.spec.ts
+++ b/test/unit/middleware/rateLimitHandler.middleware.spec.ts
@@ -1,0 +1,43 @@
+jest.mock('../../../src/controller/error.controller.ts');
+
+import { describe, expect, test, jest, afterEach } from '@jest/globals';
+import { Request, Response, NextFunction } from 'express';
+
+import { errorHandler } from '../../../src/controller/error.controller';
+import { rateLimitHandler } from '../../../src/middleware/rateLimitHandler.middleware';
+import { mockRequest, mockResponse, mockNext } from '../../mock/express.mock';
+
+const mockErrorHandler = errorHandler as jest.Mock;
+
+describe('Rate Limit Handler test suites', () => {
+
+    let req: Request;
+    let res: Response;
+    let next: NextFunction;
+
+    beforeEach(() => {
+        req = mockRequest();
+        res = mockResponse();
+        next = mockNext;
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('Should call errorHandler with err, req, res and next parameters', () => {
+
+        const err = new Error('Too Many Requests');
+        rateLimitHandler(req, res, next);
+        expect(mockErrorHandler).toHaveBeenCalledTimes(1);
+        expect(mockErrorHandler).toHaveBeenCalledWith(err, req, res, next);
+
+    });
+
+    test('Should attach statusCode property to res object, with 429 value', () => {
+
+        rateLimitHandler(req, res, next);
+        expect(res.statusCode).toBe(429);
+
+    });
+});


### PR DESCRIPTION
### JIRA link

[NTRNL-446](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-446)

### Description

This fix allows the rate limit error to propagate to the `errorHandler` function, rendering the `ERROR_PAGE` when there is a 429 Too Many Requests error.

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added


[NTRNL-446]: https://technologyprogramme.atlassian.net/browse/NTRNL-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ