### PR TITLE
change naming of IDP to CPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The GitHub request application is a tool designed to streamline and automate the
 
 ## Overview
 
-The GitHub Requests Application is a Node.js-based web application that provides a simple interface. Internal users (members of the Cognito user pool) fill in forms with requested details. When a request is submitted, an issue is created on the dedicated terraform repository, and an email is sent to the user from our `github-request.idp` email address. The email includes a message containing the user's filled-in information.
+The GitHub Requests Application is a Node.js-based web application that provides a simple interface. Internal users (members of the Cognito user pool) fill in forms with requested details. When a request is submitted, an issue is created on the dedicated terraform repository, and an email is sent to the user from our `github-request.cpe` email address. The email includes a message containing the user's filled-in information.
 
 The issue is then reviewed by the team, and further comments may be requested if necessary. Approval must be granted by two members of the team to avoid misconfigurations.
 
@@ -48,9 +48,9 @@ The issue is then reviewed by the team, and further comments may be requested if
 | GITHUB_KEY                  | GitHub key                                                          | `[github key]`                                                     |
 | GITHUB_ORG_NAME             | GitHub organisation name                                            | `Cabinet Office`                                                   |
 | GITHUB_OWNER                | GitHub owner                                                        | `cabinetoffice`                                                    |
-| GITHUB_REPO_ISSUE_ASSIGNEE  | GitHub team responsible to solve issues and update configs files    | `IDP_TEAM`                                                         |
+| GITHUB_REPO_ISSUE_ASSIGNEE  | GitHub team responsible to solve issues and update configs files    | `CPE_TEAM`                                                         |
 | GITHUB_REPO_ISSUE_LABEL     | GitHub label to categorize the related issues                       | `github-requests-app`                                              |
-| GITHUB_TERRAFORM_REPO       | GitHub private repo with terraform configurations with members, repos and teams files | `github-requests-terraform`                      |
+| GITHUB_TERRAFORM_REPO       | GitHub private repo with terraform configurations with members, repos and teams files | `cpe-terraform-infrastructure-github`                      |
 | HUMAN                       | Formatting messages form (default JSON)                             | `true` (Enable human formatting for log messages)                  |
 | LOG_LEVEL                   | Logging levels                                                      | `info`                                                             |
 | NODE_ENV                    | Node environment                                                    | `development` or `production`                                      |

--- a/docs/GitHub Requests (Application & Terraform).md
+++ b/docs/GitHub Requests (Application & Terraform).md
@@ -1,7 +1,7 @@
 # GitHub Requests (Application & Terraform)
 
-**GitHub Requests Application** is a key component designed to handle GitHub requests in a secure and consistent manner by incorporating automation with Terraform (repository [here](https://github.com/cabinetoffice/github-requests-terraform)) and implementing security access through the COLA Identity Provider.
-For example, when a new member wishes to add their GitHub account to a team, they submit an issue through this app. The IDP team verifies the issues, applies changes, and merges the Pull Request to the main branch. On the next Terraform run, the changes propagate to GitHub, granting access. This entire process occurs with complete visibility within the department, ensuring consistency, instead of relying on a single user to make changes through GitHub's web interface.
+**GitHub Requests Application** is a key component designed to handle GitHub requests in a secure and consistent manner by incorporating automation with Terraform (repository [here](https://github.com/cabinetoffice/cpe-terraform-infrastructure-github)) and implementing security access through the COLA Identity Provider.
+For example, when a new member wishes to add their GitHub account to a team, they submit an issue through this app. The CPE team verifies the issues, applies changes, and merges the Pull Request to the main branch. On the next Terraform run, the changes propagate to GitHub, granting access. This entire process occurs with complete visibility within the department, ensuring consistency, instead of relying on a single user to make changes through GitHub's web interface.
 
 ## AWS HLD Diagram
 
@@ -22,7 +22,7 @@ For example, when a new member wishes to add their GitHub account to a team, the
 
 ## Overview and Design
 
-The GitHub Requests Application is a Node.js-based web application that provides a simple interface. Internal users (members of the Cognito user pool) fill in forms with requested details. When a request is submitted, an issue is created on the dedicated terraform repository, and an email is sent to the user from our `github-request.idp` email address. The email includes a message containing the user's filled-in information.
+The GitHub Requests Application is a Node.js-based web application that provides a simple interface. Internal users (members of the Cognito user pool) fill in forms with requested details. When a request is submitted, an issue is created on the dedicated terraform repository, and an email is sent to the user from our `github-request.cpe` email address. The email includes a message containing the user's filled-in information.
 
 The issue is then reviewed by the team, and further comments may be requested if necessary. Approval must be granted by two members of the team to avoid misconfigurations.
 

--- a/src/views/confirmation.html
+++ b/src/views/confirmation.html
@@ -18,6 +18,6 @@
   </p>
 
   <p class="govuk-body">
-    If you need any further information - contact us at: github-requests.idp@digital.cabinet-office.gov.uk
+    If you need any further information - contact us at: github-requests.cpe@digital.cabinet-office.gov.uk
   </p>
 {% endblock %}

--- a/src/views/contact-us.html
+++ b/src/views/contact-us.html
@@ -4,7 +4,7 @@
 
   <h1 class="govuk-heading-l">Contact us</h1>
 
-  <p class="govuk-body">If you need any further assistance - contact us at: github-requests.idp@digital.cabinet-office.gov.uk</p>
+  <p class="govuk-body">If you need any further assistance - contact us at: github-requests.cpe@digital.cabinet-office.gov.uk</p>
 
   <h2 class="govuk-heading-m">Office hours</h2>
 

--- a/src/views/not-available.html
+++ b/src/views/not-available.html
@@ -5,5 +5,5 @@
     Sorry, the service is unavailable
   </h1>
   <p class="govuk-body-m">You will be able to use the service at a later date.</p>
-  <p>Email <a href="mailto: github-requests.idp@digital.cabinet-office.gov.uk">github-requests.idp@digital.cabinet-office.gov.uk</a> if you need more information.</p>
+  <p>Email <a href="mailto: github-requests.cpe@digital.cabinet-office.gov.uk">github-requests.cpe@digital.cabinet-office.gov.uk</a> if you need more information.</p>
 {% endblock %}


### PR DESCRIPTION
### JIRA link

Resolves [NTRNL-488](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-488)

### Description

- Change naming of IDP to CPE (CTO Platform Engineering) to match the teams current name.
### Work checklist
- Change naming of terraform repo from `github-request-terraform` to `cpe-terraform-infrastructure-github` to match our updated naming

- [x] Tests added where applicable
- [x] No vulnerability added


[NTRNL-488]: https://technologyprogramme.atlassian.net/browse/NTRNL-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ